### PR TITLE
Set correct instanceURL in session

### DIFF
--- a/RForcecom-0.3/RForcecom/R/rforcecom.login.R
+++ b/RForcecom-0.3/RForcecom/R/rforcecom.login.R
@@ -41,6 +41,7 @@ function(username, password, instanceURL, apiVersion){
  
  # Retrieve sessionID from XML
  sessionID <- xmlValue(x.root[['Body']][['loginResponse']][['result']][['sessionId']])
+ instanceURL <- sub('(https://[^/]+/).*', '\\1', xmlValue(x.root[['Body']][['loginResponse']][['result']][['serverUrl']]))
  return(c(sessionID=sessionID, instanceURL=instanceURL, apiVersion=apiVersion))
 }
 


### PR DESCRIPTION
Get the serverURL from the SOAP response after authenticating and set
the instanceURL.  This allows you to set the instanceURL to
https://www.salesforce.com/ (or https://test.salesforce.com/ for
sandboxes) when authenticating, and not have to know which instance your
org is on.

This fixes the common "Destination URL not reset" error.
