### PR TITLE
Support multiple-level child-to-parent queries

### DIFF
--- a/RForcecom-0.4.1/RForcecom/R/rforcecom.query.R
+++ b/RForcecom-0.4.1/RForcecom/R/rforcecom.query.R
@@ -32,7 +32,10 @@ function(session, soqlQuery){
  
  # Convert XML to data frame
  xns <- getNodeSet(xmlParse(t$value()),'//records')
- xdf <- xmlToDataFrame(xns)
+ xls <- lapply(lapply(xns, xmlToList), unlist)
+ xdf <- as.data.frame(do.call(rbind, xls))
+ # remove field attributes
+ xdf <- xdf[, !grepl('\\.attrs\\.', names(xdf))]
  xdf.iconv <- data.frame(lapply(xdf, iconv, from="UTF-8", to=""))
  
  # Check whether it has next record

--- a/RForcecom-0.4.1/RForcecom/R/rforcecom.queryMore.R
+++ b/RForcecom-0.4.1/RForcecom/R/rforcecom.queryMore.R
@@ -35,7 +35,10 @@ function(session, nextRecordsUrl){
  
  # Convert XML to data frame
  xns <- getNodeSet(xmlParse(t$value()),'//records')
- xdf <- xmlToDataFrame(xns)
+ xls <- lapply(lapply(xns, xmlToList), unlist)
+ xdf <- as.data.frame(do.call(rbind, xls))
+ # remove field attributes
+ xdf <- xdf[, !grepl('\\.attrs\\.', names(xdf))]
  xdf.iconv <- data.frame(lapply(xdf, iconv, from="UTF-8", to=""))
  
  # Check whether it has next record


### PR DESCRIPTION
Convert records to lists, then use unlist to flatten each record before
converting to a data frame.

This change allows correct conversion of multiple-level child-to-parent
relationships in queries, e.g.
SELECT Name, Account.Name, Account.Parent.Name FROM Contact
