### PR TITLE
Add External Id Field For Bulk Upsert Operation

### DIFF
--- a/R/rforcecom.createBulkBatch.R
+++ b/R/rforcecom.createBulkBatch.R
@@ -15,8 +15,20 @@
 #' @return A \code{list} of \code{list}s, one for each batch submitted, containing 10 parameters of the batch
 #' @examples
 #' \dontrun{
-#' n <- 100
-#' my_data <- data.frame(Name=paste('New Record:', 1:n), stringsAsFactors=FALSE)
+#' 
+#' # inserting 2 records
+#' my_data <- data.frame(Name=c('New Record 1', 'New Record 2'), 
+#'                       My_External_Id__c=c('11111','22222'), 
+#'                       stringsAsFactors=FALSE)
+#' batches_info <- rforcecom.createBulkBatch(session, 
+#'                                           jobId=job_info$id, 
+#'                                           data=my_data, 
+#'                                           multiBatch=TRUE, 
+#'                                           batchSize=50)
+#' #upserting 3 records
+#' my_data <- data.frame(My_External_Id__c=c('11111','22222', '99999'), 
+#'                       Name=c('Updated_Name1', 'Updated_Name2', 'Upserted_Record'), 
+#'                       stringsAsFactors=FALSE)
 #' batches_info <- rforcecom.createBulkBatch(session, 
 #'                                           jobId=job_info$id, 
 #'                                           data=my_data, 

--- a/man/rforcecom.createBulkBatch.Rd
+++ b/man/rforcecom.createBulkBatch.Rd
@@ -27,12 +27,24 @@ an already existing Bulk API Job by chunking into temp files
 }
 \examples{
 \dontrun{
-n <- 100
-my_data <- data.frame(Name=paste('New Record:', 1:n), stringsAsFactors=FALSE)
-batches_info <- rforcecom.createBulkBatch(session,
-                                          jobId=job_info$id,
-                                          data=my_data,
-                                          multiBatch=TRUE,
+
+# inserting 2 records
+my_data <- data.frame(Name=c('New Record 1', 'New Record 2'), 
+                      My_External_Id__c=c('11111','22222'), 
+                      stringsAsFactors=FALSE)
+batches_info <- rforcecom.createBulkBatch(session, 
+                                          jobId=job_info$id, 
+                                          data=my_data, 
+                                          multiBatch=TRUE, 
+                                          batchSize=50)
+#upserting 3 records
+my_data <- data.frame(My_External_Id__c=c('11111','22222', '99999'), 
+                      Name=c('Updated_Name1', 'Updated_Name2', 'Upserted_Record'), 
+                      stringsAsFactors=FALSE)
+batches_info <- rforcecom.createBulkBatch(session, 
+                                          jobId=job_info$id, 
+                                          data=my_data, 
+                                          multiBatch=TRUE, 
                                           batchSize=50)
 }
 }

--- a/man/rforcecom.createBulkJob.Rd
+++ b/man/rforcecom.createBulkJob.Rd
@@ -4,11 +4,12 @@
 \alias{rforcecom.createBulkJob}
 \title{Create Bulk API Job}
 \usage{
-rforcecom.createBulkJob(session,
-                               operation=c('insert', 'delete',
-                                           'query', 'upsert',
+rforcecom.createBulkJob(session, 
+                               operation=c('insert', 'delete', 
+                                           'query', 'upsert', 
                                            'update', 'hardDelete'),
                                object='Account',
+                               externalIdFieldName=NULL,
                                concurrencyMode='Parallel')
 }
 \arguments{
@@ -17,6 +18,9 @@ rforcecom.createBulkJob(session,
 \item{operation}{a character string defining the type of operation being performed}
 
 \item{object}{a character string defining the target salesforce object that the operation will be performed on}
+
+\item{externalIdFieldName}{a character string identifying a custom field that has the “External ID” attribute on the target object. 
+This field is only used when performing upserts. It will be ignored for all other operations.}
 
 \item{concurrencyMode}{a character string either "Parallel" or "Serial" that specifies whether batches should be completed
 sequentially or in parallel. Use "Serial" only if Lock contentions persist with in "Parallel" mode.}
@@ -30,10 +34,16 @@ This function initializes a Job in the Salesforce Bulk API
 \examples{
 \dontrun{
 # insert into Account
-job_info <- rforcecom.createBulkJob(session, operation='insert', object='Account')
+job_info <- rforcecom.createBulkJob(session, operation='update', object='Account')
 
 # delete from Account
 job_info <- rforcecom.createBulkJob(session, operation='delete', object='Account')
+
+# update into Account
+job_info <- rforcecom.createBulkJob(session, operation='update', object='Account')
+
+# upsert into Account
+job_info <- rforcecom.createBulkJob(session, operation='upsert', externalIdFieldName='My_External_Id__c', object='Account')
 
 # insert attachments
 job_info <- rforcecom.createBulkJob(session, operation='insert', object='Attachment')


### PR DESCRIPTION
Add the ability to specify an External Id field name which is required for performing the Bulk API Upsert Operation. The upserted dataset must have a column name that matches the External Id field specified when the job was created and the field must be configured in Salesforce as a External Id field.