### PR TITLE
Update DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,6 @@ Suggests:
     testthat
 LazyLoad: yes
 License: Apache License 2.0
-Repository: CRAN
 Date: 2015-10-26
 Collate:
     'RForcecom.R'


### PR DESCRIPTION
If the github version of the DESCRIPTION has 'Repository: CRAN' in it, then packrat cannot handle the package (as it tries to download the github version from CRAN, which will fail).  This is a workaround and I'm not quite sure of the further implications.