### PR TITLE
return NA instead of empty strings

### DIFF
--- a/R/rforcecom.getBulkQueryResult.R
+++ b/R/rforcecom.getBulkQueryResult.R
@@ -54,7 +54,7 @@ rforcecom.getBulkQueryResult <-
       res <- xmlToList(x.root)
     } else {
       con <- textConnection(res.content)
-      res <- read.csv(con, stringsAsFactors=FALSE)
+      res <- read.csv(con, stringsAsFactors=FALSE, na.strings="")
     }
     return(res)
   }


### PR DESCRIPTION
The bulk query function was returning missing values in character columns as empty strings instead of NAs.