### PR TITLE
Solves issue #69.

### DIFF
--- a/R/rforcecom.query.R
+++ b/R/rforcecom.query.R
@@ -8,7 +8,7 @@ function(session, soqlQuery, queryAll=FALSE){
  } else {
    endpointPath <- rforcecom.api.getSoqlEndpoint(session['apiVersion'])
  }
- URL <- paste(session['instanceURL'], endpointPath, RCurl::curlEscape(soqlQuery), sep="")
+ URL <- paste(session['instanceURL'], endpointPath, RCurl::curlPercentEncode(soqlQuery), sep="")
  OAuthString <- paste("Bearer", session['sessionID'])
  httpHeader <- httr::add_headers("Authorization"=OAuthString, "Accept"="application/xml")
  res <- httr::GET(url=URL, config=httpHeader)

--- a/R/rforcecom.query.R
+++ b/R/rforcecom.query.R
@@ -42,4 +42,3 @@ function(session, soqlQuery, queryAll=FALSE){
  
  return(resultset)
 }
-

--- a/R/rforcecom.utils.R
+++ b/R/rforcecom.utils.R
@@ -11,7 +11,7 @@
 #' @return \code{list} parsed from the supplied node
 xmlToList2 <- function(node){
   if (is.character(node)) 
-    node = xmlParse(node)
+    node = xmlParse(node, encoding = "UTF-8")
   if (inherits(node, "XMLAbstractDocument")) 
     node = xmlRoot(node)
   if (any(inherits(node, c("XMLTextNode", "XMLInternalTextNode")))) 

--- a/R/rforcecom.utils.R
+++ b/R/rforcecom.utils.R
@@ -57,3 +57,5 @@ query_parser <- function(xml){
   
   return(dat)
 }
+
+                      


### PR DESCRIPTION
As I said in the issue there were some problems with the use of accented characters in soqlQuery. I was able to solve it by changing the method  curlEscape() to curlPercentEncode() and by adding the encoding "UTF-8" to the node xmlParse() inside xmlToList2().